### PR TITLE
Check for config.db in local directory first.

### DIFF
--- a/cddagl/config.py
+++ b/cddagl/config.py
@@ -24,7 +24,11 @@ def init_config(basedir):
     command.upgrade(alembic_cfg, "head")
 
 def get_config_path():
-    local_app_data = os.environ['LOCALAPPDATA']
+    local_app_data = os.environ['LOCALAPPDATA']    
+    
+    if os.path.exists(os.path.join(basedir, 'configs.db')):
+        return os.path.join(basedir, 'configs.db')
+
     if not os.path.isdir(local_app_data):
         local_app_data = sys.path
 


### PR DESCRIPTION
My intention is to have the launcher look in it's own directory for config.db first, and skip the %localappdata% step entirely if its present. I've literally never done anything with python before, so I'm pretty much guessing here based on what's present and a quick google search. I hope you're ok with this, but I understand completely if you want me to keep my hands off it ;)