### PR TITLE
Remove bio-weapons mod.

### DIFF
--- a/data/mods.json
+++ b/data/mods.json
@@ -11,17 +11,6 @@
     },
     {
         "type": "browser_download",
-        "ident": "Bio_Weapon_Mod",
-        "name": "Bio-Weapon Mod",
-        "author": "Noctifer",
-        "description": "The Bio-Weapons have awoken...",
-        "size": 37435,
-        "url": "http://1drv.ms/1ZmQRiT",
-        "expected_filename": "Bio-Weapon Mod.rar",
-        "homepage": "http://smf.cataclysmdda.com/index.php?topic=11355.0"
-    },
-    {
-        "type": "browser_download",
         "ident": "ext",
         "name": "Extended Buildings",
         "description": "Adds More Buildings",


### PR DESCRIPTION
The Bio-Weapons mod was combined with the former Survivor mod to create the Cataclysm ++ mod. As a result including it is pointless and would cause conflicts with the Cataclysm ++ mod.

Since this removed looked simple enough to do I decide to make PR instead of an issue. Hope this removal doesn't break anything...