### PR TITLE
Cata++ links fixes.

### DIFF
--- a/data/mods.json
+++ b/data/mods.json
@@ -92,8 +92,8 @@
         "author": "Noctifer",
         "description": "The unofficial expansion mod for Cataclysm: Dark Days Ahead.",
         "size": 94386,
-        "url": "https://github.com/Noctifer-de-Mortem/nocs_cata_mod/archive/master.zip",
-        "homepage": "http://smf.cataclysmdda.com/index.php?topic=11248.0"
+        "url": "https://github.com/Noctifer-de-Mortem/nocts_cata_mod/archive/master.zip",
+        "homepage": "https://discourse.cataclysmdda.org/t/cataclysm-mod/10523"
     },
     {
         "type": "direct_download",


### PR DESCRIPTION
The cata++ mod linked to the old forums, updated the link to discorse, and the url for the zip file was also broken. Fixed that as well.

(Thanks Katabolic on discord for mentioning the error).
