### PR TITLE
Fix extreme slowness while fetching Build changelogs

### DIFF
--- a/cddagl/ui.py
+++ b/cddagl/ui.py
@@ -3278,10 +3278,9 @@ class UpdateGroupBox(QGroupBox):
                             fmt = '<li><span style="color:green">{0}</span></li>'
                             self.mp_content += fmt.format(_('No changes, same code as previous build!'))
                         else:
-                            for changeset_item in build_changes:
-                                change_with_links = id_regex.sub(rf'<a href="{ISSUE_URL_ROOT}\g<id>">#\g<id></a>',
-                                                                 changeset_item.text)
-                                self.mp_content += f'<li>{change_with_links}</li>'
+                            for change in build_changes:
+                                change = id_regex.sub(rf'<a href="{ISSUE_URL_ROOT}\g<id>">#\g<id></a>', change.text)
+                                self.mp_content += f'<li>{change}</li>'
                         self.mp_content += '</ul>'
 
                     self.completed.emit()

--- a/cddagl/ui.py
+++ b/cddagl/ui.py
@@ -3248,28 +3248,28 @@ class UpdateGroupBox(QGroupBox):
                     id_regex = re.compile(r'((?<![\w#])(?=[\w#])|(?<=[\w#])(?![\w#]))#(?P<id>\d+)\b')
 
                     for build_data in changelog_xml:
-                        build_date_text = None
                         if build_data.find('building').text == 'true':
                             build_status = 'IN_PROGRESS'
                         else:
                             build_status = build_data.find('result').text   ### 'SUCCESS' or 'FAILURE'
 
-                            build_timestamp = int(build_data.find('timestamp').text) // 1000
-                            build_date_utc = datetime.utcfromtimestamp(build_timestamp).replace(tzinfo=timezone.utc)
-                            build_date_local = build_date_utc.astimezone(tz=None)
-                            build_date_text = build_date_local.strftime("%c (UTC%z)")
+                        build_timestamp = int(build_data.find('timestamp').text) // 1000
+                        build_date_utc = datetime.utcfromtimestamp(build_timestamp).replace(tzinfo=timezone.utc)
+                        build_date_local = build_date_utc.astimezone(tz=None)
+                        build_date_text = build_date_local.strftime("%c (UTC%z)")
 
                         build_changes = build_data.findall(r'.//changeSet/item/msg')
                         build_number = int(build_data.find('number').text)
                         build_link = f'<a href="{BUILD_CHANGES_URL(build_number)}">Build #{build_number}</a>'
 
                         if build_status == 'IN_PROGRESS':
-                            fmt = '<h4>{0} - <span style="color:purple">{1}</span></h4>'
-                            self.mp_content += fmt.format(build_link, _('Build in progress for some platforms!'))
+                            fmt = '<h4>{0} - {1} <span style="color:purple">{2}</span></h4>'
+                            self.mp_content += fmt.format(build_link, build_date_text,
+                                                          _('build in progress for some platforms!'))
                         elif build_status == 'SUCCESS':
                             self.mp_content += '<h4>{0} - {1}</h4>'.format(build_link, build_date_text)
                         else:   ### build_status = 'FAILURE'
-                            fmt = '<h4>{0} - {1}, <span style="color:red">{2}</span></h4>'
+                            fmt = '<h4>{0} - {1} <span style="color:red">{2}</span></h4>'
                             self.mp_content += fmt.format(build_link, build_date_text,
                                                           _('but build failed for some platforms!'))
 

--- a/cddagl/ui.py
+++ b/cddagl/ui.py
@@ -3255,7 +3255,7 @@ class UpdateGroupBox(QGroupBox):
                             build_status = build_data.find('result').text   ### 'SUCCESS' or 'FAILURE'
 
                             build_timestamp = int(build_data.find('timestamp').text) // 1000
-                            build_date_utc = datetime.utcfromtimestamp(build_timestamp).astimezone(tz=timezone.utc)
+                            build_date_utc = datetime.utcfromtimestamp(build_timestamp).replace(tzinfo=timezone.utc)
                             build_date_local = build_date_utc.astimezone(tz=None)
                             build_date_text = build_date_local.strftime("%c (UTC%z)")
 

--- a/cddagl/ui.py
+++ b/cddagl/ui.py
@@ -3244,6 +3244,9 @@ class UpdateGroupBox(QGroupBox):
                     self.changelog_http_data.seek(0)
                     changelog_xml = xml.etree.ElementTree.fromstring(self.changelog_http_data.read())
 
+                    ### "((?<![\w#])(?=[\w#])|(?<=[\w#])(?![\w#]))" is like a \b that accepts "#" as word char too
+                    id_regex = re.compile(r'((?<![\w#])(?=[\w#])|(?<=[\w#])(?![\w#]))#(?P<id>\d+)\b')
+
                     for build_data in changelog_xml:
                         build_date_text = None
                         if build_data.find('building').text == 'true':
@@ -3276,7 +3279,9 @@ class UpdateGroupBox(QGroupBox):
                             self.mp_content += fmt.format(_('No changes, same code as previous build!'))
                         else:
                             for changeset_item in build_changes:
-                                self.mp_content += f'<li>{changeset_item.text}</li>'
+                                change_with_links = id_regex.sub(rf'<a href="{ISSUE_URL_ROOT}\g<id>">#\g<id></a>',
+                                                                 changeset_item.text)
+                                self.mp_content += f'<li>{change_with_links}</li>'
                         self.mp_content += '</ul>'
 
                     self.completed.emit()

--- a/cddagl/ui.py
+++ b/cddagl/ui.py
@@ -113,6 +113,14 @@ FAKE_USER_AGENT = (b'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
 
 TEMP_PREFIX = 'cddagl'
 
+def unique(seq):
+    """Return unique entries in a unordered sequence while preserving order."""
+    seen = set()
+    for x in seq:
+        if x not in seen:
+            seen.add(x)
+            yield x
+
 def clean_qt_path(path):
     return path.replace('/', '\\')
 
@@ -3258,7 +3266,8 @@ class UpdateGroupBox(QGroupBox):
                         build_date_local = build_date_utc.astimezone(tz=None)
                         build_date_text = build_date_local.strftime("%c (UTC%z)")
 
-                        build_changes = build_data.findall(r'.//changeSet/item/msg')
+                        build_changes = map(lambda x: x.text.strip(), build_data.findall(r'.//changeSet/item/msg'))
+                        build_changes = list(unique(build_changes))
                         build_number = int(build_data.find('number').text)
                         build_link = f'<a href="{BUILD_CHANGES_URL(build_number)}">Build #{build_number}</a>'
 
@@ -3279,7 +3288,7 @@ class UpdateGroupBox(QGroupBox):
                             self.mp_content += fmt.format(_('No changes, same code as previous build!'))
                         else:
                             for change in build_changes:
-                                change = id_regex.sub(rf'<a href="{ISSUE_URL_ROOT}\g<id>">#\g<id></a>', change.text)
+                                change = id_regex.sub(rf'<a href="{ISSUE_URL_ROOT}\g<id>">#\g<id></a>', change)
                                 self.mp_content += f'<li>{change}</li>'
                         self.mp_content += '</ul>'
 


### PR DESCRIPTION
Hi,

I noticed the CDDA launcher was taking way too long to display the list of build changelogs, unnecessarily delaying the update process. So, I gave a try to fix it.

The reason was that your current code use: http://gorgon.narc.ro:8080/job/Cataclysm-Matrix/changes to extract the changelogs, and that page is huge, because it has a lot of builds (also seems like Jenkins takes a while to build it for some reason).

So I replaced it with an XML API call to jenkins which provides only a small portion of recent builds and built the changelog html based on that.

The new XML API url I am using is:
http://gorgon.narc.ro:8080/job/Cataclysm-Matrix/api/xml?tree=builds[number,building,result,changeSet[items[msg]]]&xpath=//build&wrapper=builds

If you manually check both links you can already see improvement in the response time.

I also tried to keep a similar changelog format as you currently have:
![image](https://user-images.githubusercontent.com/1426680/55283816-4f4df700-5341-11e9-8201-9f5adf72b466.png)
