### PR TITLE
Pass CREATE_NEW_PROCESS_GROUP to the correct param

### DIFF
--- a/cddagl/ui.py
+++ b/cddagl/ui.py
@@ -940,7 +940,7 @@ class GameDirGroupBox(QGroupBox):
 
         try:
             game_process = subprocess.Popen(cmd, cwd=exe_dir,
-                startupinfo=subprocess.CREATE_NEW_PROCESS_GROUP)
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
         except OSError as e:
             main_window = self.get_main_window()
             status_bar = main_window.statusBar()


### PR DESCRIPTION
Running the launcher with Python 3.7 generates a crash when launching CDDA (pressing "Launch game" button).
The reason was that "CREATE_NEW_PROCESS_GROUP" to Popen was passed to the wrong named param.

I'm guessing this may have been doing nothing in pre Python 3.7 , but it crashes in Python 3.7. I'd recommend fixing it just to make the code version-proof.