### PR TITLE
Escape HTML chars from commit descriptions in changelog

### DIFF
--- a/cddagl/ui.py
+++ b/cddagl/ui.py
@@ -1815,7 +1815,8 @@ class ChangelogParsingThread(QThread):
                 format='long', locale=app_locale)
 
             build_changes = build_data.findall(r'.//changeSet/item/msg')
-            build_changes = map(lambda x: x.text.strip(), build_changes)
+            build_changes = map(lambda x: html.escape(x.text.strip(), True),
+                                build_changes)
             build_changes = list(unique(build_changes))
             build_number = int(build_data.find('number').text)
             build_link = f'<a href="{BUILD_CHANGES_URL(build_number)}">' \


### PR DESCRIPTION
Seems like I forgot to escape potential HTML chars on the Commit messages when building the Changelog list.

This fixes cases like:
![image](https://user-images.githubusercontent.com/1426680/58589663-c49e5100-8238-11e9-8608-2ea66c03a198.png)

Which should show:
![image](https://user-images.githubusercontent.com/1426680/58589667-c831d800-8238-11e9-804d-8beed6235872.png)

This also fixes a super severe security issue where a malicious dev on CDDA team could execute arbitrary javascript code on Launcher users with a maliciously crafted git commit message :P kappa