### PR TITLE
Make installer "Launch CDDAGL" checked by default

### DIFF
--- a/launcher.iss
+++ b/launcher.iss
@@ -77,7 +77,7 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 
 
 [Run]
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: unchecked nowait postinstall skipifsilent
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 
 
 [Code]


### PR DESCRIPTION
A stupid minor change to the installer, to make it start the launcher after installation by default (checkbox marked by default), since if the user is installing / updating they probably want to use it right away anyways (specially when updating).