### PR TITLE
Let user install CDDA Launcher even when previous uninstallation failed

### DIFF
--- a/launcher.iss
+++ b/launcher.iss
@@ -63,6 +63,10 @@ Name: "turkish"; MessagesFile: "compiler:Languages\Turkish.isl"
 Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 
 
+[Dirs]
+Name: "{app}"; Flags: uninsalwaysuninstall;
+
+
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}";
 
@@ -152,13 +156,4 @@ begin
     else
       Result := 'Please, uninstall existing installation of {#SetupSetting("AppName")} before running this setup!';
   end;
-end;
-
-
-//// Uninstall seems to delete all files but leaves empty directories behind
-//// Makes sure it deletes all empty directories after uninstall
-procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
-begin
-  if CurUninstallStep = usPostUninstall then
-    DelTree(ExpandConstant('{app}'), True, False, True);
 end;

--- a/launcher.iss
+++ b/launcher.iss
@@ -146,8 +146,8 @@ begin
       if UnInstallOldVersion() <> 0 then
       begin
         iMsgBoxAnswer := MsgBox('Failed to uninstall existing installation!' + #13#10
-                                + 'Try to install anyways?' + #13#10
-                                + '(This may work, specially if you manually delete installed files)',
+                                + 'Try to reinstall anyways?' + #13#10
+                                + '(This has a good chance to fix it.)',
                                 mbInformation, MB_YESNO);
         if iMsgBoxAnswer = IDNO then
           Result := 'Failed to uninstall existing installation of {#SetupSetting("AppName")}!';

--- a/launcher.iss
+++ b/launcher.iss
@@ -140,7 +140,14 @@ begin
     if iMsgBoxAnswer = IDYES then
     begin
       if UnInstallOldVersion() <> 0 then
-        Result := 'Failed to uninstall existing installation of {#SetupSetting("AppName")}!';
+      begin
+        iMsgBoxAnswer := MsgBox('Failed to uninstall existing installation!' + #13#10
+                                + 'Try to install anyways?' + #13#10
+                                + '(This may work, specially if you manually delete installed files)',
+                                mbInformation, MB_YESNO);
+        if iMsgBoxAnswer = IDNO then
+          Result := 'Failed to uninstall existing installation of {#SetupSetting("AppName")}!';
+      end
     end
     else
       Result := 'Please, uninstall existing installation of {#SetupSetting("AppName")} before running this setup!';

--- a/launcher.iss
+++ b/launcher.iss
@@ -140,7 +140,9 @@ begin
 
   if IsInstalled() then
   begin
-    iMsgBoxAnswer := MsgBox('{#SetupSetting("AppName")} is already installed. Uninstall it before proceeding?', mbInformation, MB_YESNO);
+    iMsgBoxAnswer := MsgBox('{#SetupSetting("AppName")} is already installed.' + #13#10
+                            + 'Uninstall it before proceeding?',
+                            mbInformation, MB_YESNO);
     if iMsgBoxAnswer = IDYES then
     begin
       if UnInstallOldVersion() <> 0 then


### PR DESCRIPTION
If for some reason the uninstaller isn't available to windows anymore, the installer will currently show an error message and the user has to workaround it by manually removing the CDDA installer Registry entries.

After this PR, the user will be presented with a "Try to install anyways?" question, which may fix any issue the player has.
The installer is quite resilient in this case, as it overwrites previously installed files or adds the missing ones.
IMO, it's better than leaving a potentially non-tech savvy player having to manually fix errors themselves.

I made this change because I saw one player say in CDDA Discord mention a bad experience with the launcher when they manually deleted the launcher files (including the uninstaller executable) without using the uninstaller (which still leaves the windows registry entries), which left him in a "can't install CDDA Launcher because can't uninstall CDDA Launcher".

Also, while doing this improvement, I noticed that the Pascal code to "recursively delete empty directories in the CDDA Launcher directory" wasn't working at all, and found a way simpler and better alternative. This fix will also make the update installations or "install anyways" work a bit smoother.