### PR TITLE
Increase minimum value of "automatically refresh build list"

### DIFF
--- a/cddagl/ui/views/settings.py
+++ b/cddagl/ui/views/settings.py
@@ -338,7 +338,7 @@ class UpdateSettingsGroupBox(QGroupBox):
         self.auto_refresh_builds_checkbox = auto_refresh_builds_checkbox
 
         arb_min_spinbox = QSpinBox()
-        arb_min_spinbox.setMinimum(1)
+        arb_min_spinbox.setMinimum(5)
         arb_min_spinbox.setValue(int(get_config_value(
             'auto_refresh_builds_minutes', '30')))
         arb_min_spinbox.valueChanged.connect(self.ams_changed)


### PR DESCRIPTION
A minimum of 1 min can easily make the user hit GitHub rate limit.
Increased it to 5 mins.
Also, I tested it, this change also changes saved configs with values < 5 to increase to 5.
Fixes #364