### PR TITLE
Debugged and cleaned the code of Mutation Changes

### DIFF
--- a/data/mods.json
+++ b/data/mods.json
@@ -136,8 +136,8 @@
     "category": "rebalance",
     "authors": [ "Peeved Penguin (Original Author)", "Bl4nk (Fixer)" ],
     "size": 32184,
-    "url": "https://github.com/Bl4nked/Mutation-Changes-Mod-Fix-/archive/master.zip",
-    "homepage": "https://github.com/Bl4nked/Mutation-Changes-Mod-Fix-"
+    "url": "https://github.com/Snofielf/Mutation-Changes-Snofielf-Patch/archive/master.zip",
+    "homepage": "https://github.com/Snofielf/Mutation-Changes-Snofielf-Patch"
   },
   {
     "type": "browser_download",

--- a/data/mods.json
+++ b/data/mods.json
@@ -134,7 +134,7 @@
     "name": "Mutation Changes",
     "description": "Changes, rebalances and adds some more mutations. This a fixed version to cleanse the mod of the old bugs and problems. It also has some new mutations and additions.",
     "category": "rebalance",
-    "authors": [ "Peeved Penguin (Original Author)", "Bl4nk (Fixer)" ],
+    "authors": [ "Peeved Penguin (Original Author)", "Bl4nk (Fixer)", "Snofielf (Fixer)" ],
     "size": 32184,
     "url": "https://github.com/Snofielf/Mutation-Changes-Snofielf-Patch/archive/master.zip",
     "homepage": "https://github.com/Snofielf/Mutation-Changes-Snofielf-Patch"


### PR DESCRIPTION
OVERVIEW:
The Mutation Changes mod is that one mod that I think every mutant addict should try once just due to how much it expands upon the mutations that exist in the game. Sadly there has not been a single update to this mod in a literal year, so I took it upon myself to make the mod work better.

STUFF CHANGED:
-Removed scenarios.json. This was redundant code that messed up Lab Starts.
-Re-balanced the crafting recipes for the tortoise mutagen/serum in recipe_medsandchemicals.json.
-Re-formatted the code in recipe_medsandchemicals.json to make it more inline with the rest of the mutagen crafting recipies.

WHY I'M WORKING ON THIS:
I'm updating this mod in hopes of getting it mainlined to the master CDDA code because there hasn't been a single decent overhaul to mutations in a hot minute. Plus this mod is just adds and re balances to the mutations that are already in the game.