### PR TITLE
Fix missing `alembicrepo` folder when running `setup.py freeze`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -244,6 +244,7 @@ class FreezeWithPyInstaller(ExtendedCommand):
         # Additional files
         added_files = [
             ('alembic', 'alembic'),
+            ('alembicrepo', 'alembicrepo'),
             ('data', 'data'),
             ('cddagl/resources', 'cddagl/resources'),
             ('cddagl/VERSION', 'cddagl')


### PR DESCRIPTION
So I tried to compile the portable version of the launcher locally and got this error when trying to run the resulting exe
```
Type: <class 'alembic.util.exc.CommandError'>
Value: Path doesn't exist: 'D:\\Game\\CataclysmCODE\\CDDA-Game-Launcher\\dist\\launcher\\alembicrepo'. Please use the 'init' command to create a new scripts folder.
Traceback:
File "cddagl\launcher.py", line 161, in <module>

File "cddagl\launcher.py", line 154, in run_cddagl
File "cddagl\sql\functions.py", line 43, in init_config
File "alembic\command.py", line 274, in upgrade
File "alembic\script\base.py", line 148, in from_config
File "alembic\script\base.py", line 70, in __init__
```

And I think it came from a missing line in `setup.py`, this PR appears to fix it